### PR TITLE
Fix to find the correct Qt path

### DIFF
--- a/src/macdeployqt/shared/shared.cpp
+++ b/src/macdeployqt/shared/shared.cpp
@@ -850,7 +850,7 @@ DeploymentInfo deployQtFrameworks(QList<FrameworkInfo> frameworks,
         copiedFrameworks.append(framework.frameworkName);
 
         // Get the qt path from one of the Qt frameworks;
-        if (deploymentInfo.qtPath.isNull() && framework.frameworkName.contains("Qt")
+        if (deploymentInfo.qtPath.isNull() && framework.frameworkName.contains("Qt") && framework.frameworkName.contains(".framework")
             && framework.frameworkDirectory.contains("/lib"))
         {
             deploymentInfo.qtPath = framework.frameworkDirectory;


### PR DESCRIPTION
I was using the **macdeployqt** tool but I found an error when the tool tries to copy the Qt Plugins that my application depends on.

The problem was that I am linking my application with VTK shared libraries and one of the libraries is called **libvtkGUISupportQtOpenGL.dylib**. 

In this case, the **macdeployqt** tool thinks that this shared library is a Qt framework and sets the **deploymentInfo.qtPath** to the path of a VTK library, which has nothing to do with Qt Frameworks. At the end of the process, back in **main.cpp** it tries to copy the Qt Plugins from the same directory as **libvtkGUISupportQtOpenGL.dylib** thus rising an error.

So I added a third condition in the line that check if the current framework being analysed is in fact a Qt Framework.